### PR TITLE
Resolve Windows OS encoding bug

### DIFF
--- a/src/gened/db.py
+++ b/src/gened/db.py
@@ -74,8 +74,8 @@ def init_db() -> None:
         db.executescript(f.read())
 
     # App-specific schema in the app's package
-    with current_app.open_resource('schema.sql', 'r') as f:
-        db.executescript(f.read())
+    with current_app.open_resource('schema.sql', 'rb') as f:
+        db.executescript(f.read().decode('utf-8'))
 
     # Mark all existing migrations as applied (since this is a fresh DB)
     for func in _on_init_db_callbacks:

--- a/src/gened/migrate.py
+++ b/src/gened/migrate.py
@@ -90,7 +90,7 @@ def _apply_migrations(migrations: Iterable[MigrationDict]) -> None:
 def _migration_info(resource: Traversable) -> MigrationDict:
     """Get info on a migration, provided as an importlib.resources resource."""
     db = get_db()
-    with resources.as_file(resource) as path, path.open() as f:
+    with resources.as_file(resource) as path, path.open(encoding='utf-8') as f:
         name = path.name
         info: MigrationDict = {
             'name': name,


### PR DESCRIPTION
This commit, if applied, will resolve the issues on Windows OS caused by encoding.

```bash
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\user\OneDrive\Desktop\Gen-Ed\src\gened\db.py", line 90, in init_db_command
init_db()
File "C:\Users\user\OneDrive\Desktop\Gen-Ed\src\gened\db.py", line 78, in init_db
db.executescript(f.read())
^^^^^^^^
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.2544.0_x64__qbz5n2kfra8p0\Lib\encodings\cp1252.py", line 23, in decode
return codecs.charmap_decode(input,self.errors,decoding_table)[0]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```