### PR TITLE
Show query time and fix context name in recent queries

### DIFF
--- a/src/components/code_queries/templates/recent_queries.html
+++ b/src/components/code_queries/templates/recent_queries.html
@@ -14,8 +14,9 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="{{url_for('helper.help_view', query_id=prev.id)}}" class="button is-link is-outlined is-rounded p-2">View</a>
         <a href="{{url_for('helper.help_form', query_id=prev.id)}}" class="button is-link is-outlined is-rounded p-2">Retry</a>
       </div>
-      {% if prev.context_name %}
-        <p>{{ prev.context_name }}:</p>
+      <p class="is-size-7 has-text-grey">{{ prev.time | localtime }}</p>
+      {% if prev.context %}
+        <p>{{ prev.context }}:</p>
       {% endif %}
       {% if prev.code %}
         <p><code>{{prev.code | truncate(50)}}</code></p>


### PR DESCRIPTION
The context name never showed up in the recent queries list. The template checked `prev.context_name`, but `get_queries()` in `code_queries/data.py` selects that column as `t.context_name AS context`, so the condition was always false.

I also added the query timestamp above the context line, using the existing `localtime` filter (`t.query_time AS time`).

Both changes are in one commit since they touch the same few lines, but I can split them if you'd rather review them separately.

`mypy` passes (90 files) and `pytest` passes (170 tests) locally.

I wasn't sure about the placement or styling of the timestamp, so let me know if you want it somewhere else in the entry.
